### PR TITLE
Lattice revamped

### DIFF
--- a/sample_inputs/integration.ini
+++ b/sample_inputs/integration.ini
@@ -45,8 +45,8 @@
 
 # The version of RAMPACK this file is targeted to. Input file versions lower than the current RAMPACK version should be
 # parsed properly, however some new features will be limited.
-# Current version is: 0.3
-version = 0.3
+# Current version is: 0.4
+version = 0.4
 
 # Initial dimensions of the orthorhombic simulation box. Supported variants:
 # 1. "[side length]"

--- a/sample_inputs/integration.ini
+++ b/sample_inputs/integration.ini
@@ -66,12 +66,13 @@ initialDimensions = 100 100 100
 # "[cell specification]" | "[transformation 1]" | ... | "[transformation n]" | "[population scheme]"
 #
 # Optional transformations can be stacked together and are separated using a pipe "|". Population scheme is also
-# optional (implicit behaviour is equivalent to "populate serial xyz" - see below).
+# optional (implicit behaviour is equivalent to "populate serial" - see below).
 #
 # "[cell specification]" specifies the type of a unit cell and a number of those cells. Variants:
 # 1. "[cell specification]" := "[cell type] default"
-#    create n x n x n (where n is chosen automatically) lattice just large enough to accommodate all particles.
-#    "initialDimensions" cannot be "auto" in this variant - cell dimensions are inferred from the box size.
+#    create a lattice with automatic number of cells large enough to accommodate all particles; at the same time, the
+#    algorithm tries to keep the the heights of the unit cell as close to each other as possible. "initialDimensions"
+#    cannot be "auto" in this variant - cell dimensions are inferred from the box size.
 # 2. "[cell specification]" := "[cell type] ncell [nx] [ny] [nz]"
 #    number of cells is specified explicitly. Cell dimensions are calculated based on the box size (thus is cannot be
 #    "auto" in this case)
@@ -157,7 +158,8 @@ initialDimensions = 100 100 100
 #    Populates the lattice cell by cell looping through cell indices. The order of loops is given, from outermost to
 #    innermost, by "[axis order]". For example, for "[axis order]" = "yxz", first z column is filled, then zx plane is
 #    filled with those columns, and lastly those planes are stacked in y direction. Within a cell, molecules are placed
-#    in the order in which they appear within the cell. Default values of "[axis order]" is "xyz".
+#    in the order in which they appear within the cell. If "[axis order]" is not specified manually, the first axis is
+#    the one with most lattice cells and the last - the one with least.
 # 2. "[population scheme]" := "random [rng seed]"
 #    Molecules are placed at random using RNG sequence seeded with "[rng seed]". However, their order is not completely
 #    random - particles with close indices will have relatively close real-space positions (for a better cache

--- a/sample_inputs/overlap_reduction.ini
+++ b/sample_inputs/overlap_reduction.ini
@@ -4,7 +4,7 @@
 # The general information about input file, its structure and meaning of parameters are mainly gathered in
 # integration.ini file. This input file only supplements it with information about overlap reduction mode.
 
-version = 0.3
+version = 0.4
 
 initialDimensions = 7 7 7
 initialArrangement = lattice default

--- a/src/utils/Version.h
+++ b/src/utils/Version.h
@@ -97,7 +97,7 @@ public:
 };
 
 
-constexpr Version CURRENT_VERSION{0, 3, 0};
+constexpr Version CURRENT_VERSION{0, 4, 0};
 
 
 #endif //RAMPACK_VERSION_H


### PR DESCRIPTION
* closes #14
* `populate serial` and defaulted populator (ones without explicit axis order) now populate in a smart way looking at number of lattice cells in each direction
* version bumped to 0.4