### PR TITLE
Many fixes

### DIFF
--- a/sample_inputs/integration.pyon
+++ b/sample_inputs/integration.pyon
@@ -1,5 +1,5 @@
 rampack(
-    version = "0.9.2",
+    version = "0.9.3",
     arrangement = lattice(cell=sc, box_dim=100, n_shapes=1000),
     temperature = 1,
     move_types = [translation(step=10)],

--- a/sample_inputs/overlap_reduction.pyon
+++ b/sample_inputs/overlap_reduction.pyon
@@ -1,5 +1,5 @@
 rampack(
-    version = "0.9.2",
+    version = "0.9.3",
     arrangement = lattice(cell=sc, box_dim=7, n_shapes=512),
     temperature = 1,
     pressure = 20,

--- a/script/rampack_completion.bash
+++ b/script/rampack_completion.bash
@@ -278,7 +278,7 @@ _rampack() {
 		return
 	fi
 
-	COMPREPLY=($(compgen -W "casino preview shape-preview trajectory -h --help" -- "$cur"))
+	COMPREPLY=($(compgen -W "casino preview shape-preview trajectory -h --help help -v --version version" -- "$cur"))
 }
 
 

--- a/script/rampack_completion.zsh
+++ b/script/rampack_completion.zsh
@@ -102,7 +102,8 @@ function _rampack {
 		"preview\:preview\ of\ the\ initial\ configuration"
 		"shape-preview\:preview\ of\ the\ shape"
 		"trajectory\:visualization\ and\ analysis\ of\ recorded\ trajectories"
-		{-h,--help}"\:general\ help"
+		{-h,--help,help}"\:general\ help"
+		{-v,--version,version}"\:shows\ current\ version"
 	)
 
 	_arguments \

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 
 #include "frontend/modes/HelpMode.h"
+#include "frontend/modes/VersionMode.h"
 #include "frontend/modes/CasinoMode.h"
 #include "frontend/modes/PreviewMode.h"
 #include "frontend/modes/ShapePreviewMode.h"
@@ -50,8 +51,10 @@ namespace {
     }
 
     int handle_commands(const std::string &cmd, const std::string &mode, int argc, char **argv) {
-        if (mode == "-h" || mode == "--help")
-            return HelpMode(logger).main(argc, argv);
+        if (mode == "-h" || mode == "--help" || mode == "help")
+            return HelpMode(logger, cmd).main(argc, argv);
+        else if (mode == "-v" || mode == "--version" || mode == "version")
+            return VersionMode(logger).main(argc, argv);
         else if (mode == "casino")
             return CasinoMode(logger).main(argc, argv);
         else if (mode == "preview")

--- a/src/core/io/RamtrjIO.h
+++ b/src/core/io/RamtrjIO.h
@@ -11,7 +11,9 @@
 #include "core/Shape.h"
 #include "utils/Exceptions.h"
 
-
+/**
+ * @brief Exception thrown when reading/writing RAMTRJ data.
+ */
 class RamtrjException : public ValidationException {
 public:
     using ValidationException::ValidationException;

--- a/src/core/io/WolframWriter.h
+++ b/src/core/io/WolframWriter.h
@@ -45,6 +45,7 @@ public:
     /**
      * @brief Creates the class.
      * @param style style of the output
+     * @param params auxiliary parameters passed to Wolfram ShapePrinter
      */
     explicit WolframWriter(WolframStyle style = WolframStyle::STANDARD, std::map<std::string, std::string> params = {})
         : style{style}, params{std::move(params)} { }

--- a/src/core/lattice/CellOptimizationTransformer.cpp
+++ b/src/core/lattice/CellOptimizationTransformer.cpp
@@ -15,8 +15,11 @@
 void CellOptimizationTransformer::transform(Lattice &lattice, const ShapeTraits &shapeTraits) const {
     const auto &interaction = shapeTraits.getInteraction();
 
-    Expects(interaction.hasHardPart());
-    Expects(lattice.isNormalized());
+    TransformerValidateMsg(interaction.hasHardPart(),
+                           "Interaction must have a hard component to perform distance optimization");
+    TransformerValidateMsg(lattice.isNormalized(),
+                           "Relative coordinates in unit cell must be in range [0, 1) to perform distance "
+                           "optimization");
 
     auto pbc = std::make_unique<PeriodicBoundaryConditions>();
     Packing testPacking(lattice.getLatticeBox(), lattice.generateMolecules(), std::move(pbc), interaction);
@@ -27,8 +30,11 @@ void CellOptimizationTransformer::transform(Lattice &lattice, const ShapeTraits 
 
     const auto &newHeights = newBox.getHeights();
     const auto &dim = lattice.getDimensions();
-    for (std::size_t i{}; i < 3; i++)
-        Expects(newHeights[i] + this->spacings[i] * static_cast<double>(dim[i]) > 0);
+    for (std::size_t i{}; i < 3; i++) {
+        TransformerValidateMsg(newHeights[i] + this->spacings[i] * static_cast<double>(dim[i]) > 0,
+                               "Negative spacing has too large magnitude: it yields negative box height on axis "
+                               + std::string{static_cast<char>('x' + i)} + " after shrinking");
+    }
     auto newSides = newBox.getSides();
     for (std::size_t i{}; i < 3; i++) {
         double scaleFactor = (newHeights[i] + spacings[i] * static_cast<double>(dim[i])) / newHeights[i];

--- a/src/core/lattice/CellOptimizationTransformer.h
+++ b/src/core/lattice/CellOptimizationTransformer.h
@@ -42,6 +42,7 @@ public:
      * cell faces is increased by @a spacing (in the direction ortohgonal to the face).
      * @param lattice lattice to optimized. It can be either regular or irregular, but is has to be normalized (see
      * Lattice::normalize())
+     * @param shapeTraits ShapeTraits of the shape residing in the lattice.
      */
     void transform(Lattice &lattice, const ShapeTraits &shapeTraits) const override;
 };

--- a/src/core/lattice/ColumnarTransformer.cpp
+++ b/src/core/lattice/ColumnarTransformer.cpp
@@ -11,8 +11,10 @@
 
 
 void ColumnarTransformer::transform(Lattice &lattice, [[maybe_unused]] const ShapeTraits &shapeTraits) const {
-    Expects(lattice.isRegular());
-    Expects(lattice.isNormalized());
+    TransformerValidateMsg(lattice.isRegular(), "Columnar transformation can only be applied to a regular lattice");
+    TransformerValidateMsg(lattice.isNormalized(),
+                           "Relative coordinates in unit cell must be in range [0, 1) to perform distance "
+                           "optimization");
 
     const auto &unitCell = lattice.getUnitCell();
     auto columnAssociation = LatticeTraits::getColumnAssociation(unitCell, this->columnAxis);

--- a/src/core/lattice/ColumnarTransformer.h
+++ b/src/core/lattice/ColumnarTransformer.h
@@ -41,6 +41,7 @@ public:
      * from the constructor. This third relative coordinate is then translated by a random amount moving the whole
      * column. Coordinate normalization is performed if needed.
      * @param lattice lattice to be "columnarized". It has to be regular and normalized (see Lattice::normalize()).
+     * @param shapeTraits ShapeTraits of the shape residing in the lattice.
      */
     void transform(Lattice &lattice, const ShapeTraits &shapeTraits) const override;
 };

--- a/src/core/lattice/FlipRandomizingTransformer.h
+++ b/src/core/lattice/FlipRandomizingTransformer.h
@@ -34,6 +34,7 @@ public:
      * lattice is always irregular. Lattice does not have to be normalized. If it was normalized prior to flip
      * transformations, it will be renormalized afterwards (as rotation around the geometric origin may require applying
      * a translation, some particles may end up outside their cells).
+     * @param shapeTraits ShapeTraits of the shape residing in the lattice.
      */
     void transform(Lattice &lattice, const ShapeTraits &shapeTraits) const override;
 };

--- a/src/core/lattice/Lattice.h
+++ b/src/core/lattice/Lattice.h
@@ -102,7 +102,7 @@ public:
     [[nodiscard]] bool isRegular() const { return this->isRegular_; }
 
     /**
-     * @brief Returns @a true, if all molecules in the latrice have normalized relative cell coordinates (in the range
+     * @brief Returns @a true, if all molecules in the lattice have normalized relative cell coordinates (in the range
      * [0, 1)).
      */
     [[nodiscard]] bool isNormalized() const;

--- a/src/core/lattice/LatticeTransformer.h
+++ b/src/core/lattice/LatticeTransformer.h
@@ -7,6 +7,21 @@
 
 #include "Lattice.h"
 #include "core/ShapeTraits.h"
+#include "utils/Exceptions.h"
+
+
+#define TransformerValidateMsg(cond, msg) EXCEPTIONS_BLOCK(                                                         \
+    if (!(cond))                                                                                                    \
+        throw TransformerException(msg);                                                                            \
+)
+
+/**
+ * @brief Exception thrown when performing lattice transformations.
+ */
+class TransformerException : public ValidationException {
+public:
+    using ValidationException::ValidationException;
+};
 
 
 /**

--- a/src/core/lattice/LayerWiseTransformer.cpp
+++ b/src/core/lattice/LayerWiseTransformer.cpp
@@ -9,8 +9,10 @@
 
 
 void LayerWiseTransformer::transform(Lattice &lattice, [[maybe_unused]] const ShapeTraits &shapeTraits) const {
-    Expects(lattice.isRegular());
-    Expects(lattice.isNormalized());
+    TransformerValidateMsg(lattice.isRegular(), "Lattice must be regular for layerwise transforming operations");
+    TransformerValidateMsg(lattice.isNormalized(),
+                           "Relative coordinates in unit cell must be in range [0, 1) to perform layerwise "
+                           "transforimng operation");
 
     auto cell = lattice.getSpecificCell(0, 0, 0);
     auto layerAssociation = LatticeTraits::getLayerAssociation(cell, this->axis);
@@ -44,8 +46,9 @@ void LayerWiseTransformer::recalculateUnitCell(UnitCell &cell, LatticeTraits::La
     std::size_t axisIdx = LatticeTraits::axisToIndex(this->axis);
 
     // Modify dimensions
-    ExpectsMsg(latticeDim[axisIdx] % cellFactor == 0,
-               "Lattice dimensions incompatible with the requested number of layers");
+    TransformerValidateMsg(latticeDim[axisIdx] % cellFactor == 0,
+                           "Lattice dimensions should incorporate the number of layers which is an integer multiple of "
+                           + std::to_string(cellFactor) + " to perform layerwise transforming operation");
     latticeDim[axisIdx] /= cellFactor;
 
     // Modify layerAssociation - as many unit cells are joined, we have to replicate layers "cellFactor" times

--- a/src/core/lattice/LayerWiseTransformer.h
+++ b/src/core/lattice/LayerWiseTransformer.h
@@ -55,6 +55,7 @@ public:
      * described.
      * @param lattice lattice to be transformed. Is has to be both regular and normalized. The resulting lattice remains
      * regular, but may no longer be normalized if transformShape() places the shape outside of a unit cell
+     * @param shapeTraits ShapeTraits of the shape residing in the lattice.
      */
     void transform(Lattice &lattice, const ShapeTraits &shapeTraits) const final;
 };

--- a/src/core/move_samplers/RototranslationSampler.h
+++ b/src/core/move_samplers/RototranslationSampler.h
@@ -21,8 +21,11 @@ private:
     double translationStepSize{};
     std::optional<double> rotationStepSize{};
     double maxTranslationStepSize{};
+    bool isMaxTranslationStepSizeImplicit{};
 
     void calculateRotationStepSizeIfNeeded(const Interaction &interaction);
+    void adjustMaxTranslationStepSize(const Packing &packing);
+    bool increaseTranslationStepSize();
 
 public:
    /**

--- a/src/core/move_samplers/TranslationSampler.h
+++ b/src/core/move_samplers/TranslationSampler.h
@@ -18,6 +18,9 @@ class TranslationSampler : public MoveSampler {
 private:
     double translationStepSize{};
     double maxTranslationStepSize{};
+    bool isMaxTranslationStepSizeImplicit{};
+
+    void adjustMaxTranslationStepSize(const Packing &packing);
 
 public:
     /**

--- a/src/core/shapes/PolyspherocylinderTraits.h
+++ b/src/core/shapes/PolyspherocylinderTraits.h
@@ -82,6 +82,7 @@ public:
          * @param primaryAxis the primary axis of the molecule
          * @param secondaryAxis the secondary axis of the polymer (should be orthogonal to the primary one)
          * @param geometricOrigin geometric origin of the molecule which can be different that the mass centre
+         * @param volume volume of the shape
          * @param customNamedPoints custom named points in addition to default ones (see
          * PolyspherocylinderGeometry::getNamedPoint)
          */

--- a/src/frontend/legacy/IniParametersFactory.cpp
+++ b/src/frontend/legacy/IniParametersFactory.cpp
@@ -100,9 +100,6 @@ namespace {
 
         std::size_t numDomains = std::accumulate(domainDivisions.begin(), domainDivisions.end(), 1, std::multiplies<>{});
         ValidateMsg(numDomains > 0, "Number of domains should be positive");
-        ValidateMsg(numDomains <= static_cast<std::size_t>(OMP_MAXTHREADS),
-                    "Number of domains cannot be larger than number of available threads ("
-                    + std::to_string(OMP_MAXTHREADS) + ")");
 
         return domainDivisions;
     }
@@ -116,9 +113,6 @@ namespace {
         else
             scalingThreads = std::stoul(scalingThreadsStr);
         ValidateMsg(scalingThreads > 0, "Number of scaling threads should be positive");
-        ValidateMsg(scalingThreads <= static_cast<std::size_t>(OMP_MAXTHREADS),
-                    "Number of scaling threads cannot be larger than number of available threads ("
-                    + std::to_string(OMP_MAXTHREADS) + ")");
         return scalingThreads;
     }
 

--- a/src/frontend/matchers/RampackMatcher.cpp
+++ b/src/frontend/matchers/RampackMatcher.cpp
@@ -322,17 +322,13 @@ namespace {
         auto moveThreadsMax = MatcherString("max")
             .mapTo([](const std::string&) -> std::size_t { return OMP_MAXTHREADS; });
         auto moveThreadsInt = MatcherInt{}
-            .inRange(1, OMP_MAXTHREADS)
+            .positive()
             .mapTo<std::size_t>();
         return moveThreadsMax | moveThreadsInt;
     }
 
     MatcherArray create_domain_divisions() {
         return MatcherArray(MatcherInt{}.positive().mapTo<std::size_t>(), 3)
-            .filter([](const ArrayData &array) {
-                auto stdArray = array.asStdArray<std::size_t, 3>();
-                return std::accumulate(stdArray.begin(), stdArray.end(), 1, std::multiplies<>{}) <= OMP_MAXTHREADS;
-            })
             .mapToStdArray<std::size_t, 3>();
     }
 

--- a/src/frontend/modes/HelpMode.cpp
+++ b/src/frontend/modes/HelpMode.cpp
@@ -6,28 +6,31 @@
 #include "utils/Fold.h"
 
 
-int HelpMode::main([[maybe_unused]] int argc, char **argv) {
-    std::string cmd = argv[0];
+int HelpMode::main([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
     std::ostream &rawOut = this->logger;
 
     rawOut << Fold("Random and Maximal PACKing PACKage - computational package dedicated to simulate various packing "
                    "models using Monte Carlo method.").width(80) << std::endl;
     rawOut << std::endl;
-    rawOut << "Usage: " << cmd << " [mode] (mode dependent parameters). " << std::endl;
+    rawOut << "Usage: " << this->cmd << " [mode] (mode dependent parameters). " << std::endl;
     rawOut << std::endl;
-    rawOut << "Available modules:" << std::endl;
+    rawOut << "Available modes:" << std::endl;
     rawOut << "casino" << std::endl;
     rawOut << Fold("Monte Carlo sampling for both hard and soft potentials.").width(80).margin(4) << std::endl;
     rawOut << "preview" << std::endl;
     rawOut << Fold("Based on the input file generate initial configuration and store it in a given format.")
-            .width(80).margin(4) << std::endl;
+              .width(80).margin(4) << std::endl;
     rawOut << "shape-preview" << std::endl;
     rawOut << Fold("Provides information and preview for a given shape.").width(80).margin(4) << std::endl;
     rawOut << "trajectory" << std::endl;
     rawOut << Fold("Replays recorded simulation trajectory and performs some operations on it.")
-            .width(80).margin(4) << std::endl;
+              .width(80).margin(4) << std::endl;
+    rawOut << "-v, --version, version" << std::endl;
+    rawOut << Fold("Shows current version.").width(80).margin(4) << std::endl;
+    rawOut << "-h, --help, help" << std::endl;
+    rawOut << Fold("Shows this help.").width(80).margin(4) << std::endl;
     rawOut << std::endl;
-    rawOut << "Type " + cmd + " [mode] --help to get help on the specific mode." << std::endl;
+    rawOut << "Type " + this->cmd + " [mode] --help to get help on the specific mode." << std::endl;
 
     return EXIT_SUCCESS;
 }

--- a/src/frontend/modes/HelpMode.h
+++ b/src/frontend/modes/HelpMode.h
@@ -10,8 +10,11 @@
 
 
 class HelpMode : public ModeBase {
+private:
+    std::string cmd;    // Original cmd (not argv[0], which is now cmd + mode combined)
+
 public:
-    explicit HelpMode(Logger &logger) : ModeBase(logger) { }
+    explicit HelpMode(Logger &logger, std::string cmd) : ModeBase(logger), cmd{std::move(cmd)} { }
 
     int main(int argc, char **argv);
 };

--- a/src/frontend/modes/TrajectoryMode.cpp
+++ b/src/frontend/modes/TrajectoryMode.cpp
@@ -58,8 +58,8 @@ int TrajectoryMode::main(int argc, char **argv) {
                              "-O (--observable)",
              cxxopts::value<std::string>(obsOutputFilename))
             ("O,observable", "replays the simulation and calculates specified observables (format as in the input file). "
-                             "Observables can be passed using multiple options (-o obs1 -o obs2) or pipe-separated in a "
-                             "single one (-o 'obs1|obs2'). It is advisable to put the argument in '...' to escape shell "
+                             "Observables can be passed using multiple options (-O obs1 -O obs2) or pipe-separated in a "
+                             "single one (-O 'obs1|obs2'). It is advisable to put the argument in '...' to escape shell "
                              "special characters '()\"\"|'",
              cxxopts::value<std::vector<std::string>>(observables))
             ("b,output-bulk-obs", "calculate bulk observables and output them to the file with a name given by the "
@@ -68,8 +68,8 @@ int TrajectoryMode::main(int argc, char **argv) {
                                   "are specified using -B (--bulk-observable)",
              cxxopts::value<std::string>(bulkObsOutputFilename))
             ("B,bulk-observable", "replays the simulation and calculates specified bulk observables (format as in the "
-                                  "input file). Observables can be passed using multiple options (-o obs1 -o obs2) "
-                                  "or pipe-separated in a single one (-o 'obs1|obs2'). It is advisable to put the argument "
+                                  "input file). Observables can be passed using multiple options (-B obs1 -B obs2) "
+                                  "or pipe-separated in a single one (-B 'obs1|obs2'). It is advisable to put the argument "
                                   "in '...' to escape shell special characters '()\"\"|'",
              cxxopts::value<std::vector<std::string>>(bulkObservables))
             ("a,averaging-start", "specifies when the averaging starts. It is used for bulk observables",

--- a/src/frontend/modes/VersionMode.cpp
+++ b/src/frontend/modes/VersionMode.cpp
@@ -1,0 +1,15 @@
+//
+// Created by Piotr Kubala on 15/02/2023.
+//
+
+#include "VersionMode.h"
+#include "utils/Version.h"
+
+
+int VersionMode::main([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
+    std::ostream &rawOut = this->logger;
+
+    rawOut << "RAMPACK v" << CURRENT_VERSION << std::endl;
+
+    return 0;
+}

--- a/src/frontend/modes/VersionMode.h
+++ b/src/frontend/modes/VersionMode.h
@@ -1,0 +1,19 @@
+//
+// Created by Piotr Kubala on 15/02/2023.
+//
+
+#ifndef RAMPACK_VERSIONMODE_H
+#define RAMPACK_VERSIONMODE_H
+
+#include "frontend/ModeBase.h"
+
+
+class VersionMode : public ModeBase {
+public:
+    explicit VersionMode(Logger &logger) : ModeBase(logger) { }
+
+    int main(int argc, char **argv);
+};
+
+
+#endif //RAMPACK_VERSIONMODE_H

--- a/src/utils/Config.h
+++ b/src/utils/Config.h
@@ -12,26 +12,32 @@
 #include <vector>
 #include <algorithm>
 
+#include "Exceptions.h"
+
+
+/**
+ * @brief Base class for Config exceptions.
+ */
+class ConfigException : public ValidationException {
+public:
+    using ValidationException::ValidationException;
+};
 
 /**
  * @brief An exception thrown if there was a problem parsing config in Config.
  */
-class ConfigParseException : public std::runtime_error
-{
+class ConfigParseException : public ConfigException {
 public:
-    explicit ConfigParseException(const std::string & _what) : std::runtime_error(_what)
-    {}
+    using ConfigException::ConfigException;
 };
 
 
 /**
  * @brief An exception thrown if there was an access to nonexistent field in Config.
  */
-class ConfigNoFieldException : public std::runtime_error
-{
+class ConfigNoFieldException : public ConfigException {
 public:
-    explicit ConfigNoFieldException(const std::string & _what) : std::runtime_error(_what)
-    {}
+    using ConfigException::ConfigException;
 };
 
 

--- a/src/utils/Exceptions.h
+++ b/src/utils/Exceptions.h
@@ -101,6 +101,12 @@ private:
                                 const std::string &condition_, const std::string &message_);
 
 public:
+    [[nodiscard]] const std::string &getFile() const { return this->file; }
+    [[nodiscard]] const std::string &getFunction() const { return this->function; }
+    [[nodiscard]] std::size_t getLine() const { return this->line; }
+    [[nodiscard]] const std::string &getCondition() const { return this->condition; }
+    [[nodiscard]] const std::string &getMessage() const { return this->message; }
+
     ContractException(std::string file, std::string function, std::size_t line, std::string condition,
                       std::string message)
             : InternalError(ContractException::makeWhat(file, function, line, condition, message)),

--- a/src/utils/Version.h
+++ b/src/utils/Version.h
@@ -97,7 +97,7 @@ public:
 };
 
 
-constexpr Version CURRENT_VERSION{0, 9, 2};
+constexpr Version CURRENT_VERSION{0, 9, 3};
 
 // Auxiliary versions user in the code
 


### PR DESCRIPTION
This introduces several fixes and enhancements:
* typo fixes
* `--version` command
* some input validation errors were reported as internal errors (closes #52, closes #51)
* `translation` and `rototranslation` translation step sizes now don't draw indefinitely in gases (closes #48)
* number of `OpenMP` threads in the input file may now exceed theoretical limit (closes #53)