### PR TITLE
Output coherence

### DIFF
--- a/src/core/ObservablesCollector.h
+++ b/src/core/ObservablesCollector.h
@@ -44,6 +44,7 @@ private:
     std::vector<std::size_t> snapshotCycleNumbers;
     std::vector<std::vector<std::string>> snapshotValues;
     std::vector<std::vector<double>> averagingValues;
+    std::size_t onTheFlyLastCycleNumber{};
     std::unique_ptr<std::iostream> onTheFlyOut;
 
     mutable double computationMicroseconds{};
@@ -53,6 +54,7 @@ private:
     void doPrintSnapshotHeader(std::ostream &out, bool printNewline = true) const;
     void doPrintSnapshotValues(std::ostream &out, std::size_t snapshotIdx) const;
     void verifyOnTheFlyOutputHeader();
+    void findOnTheFlyLastCycleNumber();
 
 public:
     /**
@@ -130,9 +132,15 @@ public:
     void attachOnTheFlyOutput(std::unique_ptr<std::iostream> out);
 
     /**
+     * @brief Returns last cycle number in the on-the-fly observable output.
+     * @details If no output is attached, it returns 0.
+     */
+    [[nodiscard]] std::size_t getOnTheFlyOutputLastCycleNumber() const { return this->onTheFlyLastCycleNumber; }
+
+    /**
      * @brief Detaches and returns "on the fly" output stream (or @a nullptr if nothing is attached).
      */
-    std::unique_ptr<std::ostream> detachOnTheFlyOutput() { return std::move(this->onTheFlyOut); }
+    std::unique_ptr<std::iostream> detachOnTheFlyOutput();
 
     /**
      * @brief Generate a short inline string with current interval and nominal values of all ObservableType::INLINE

--- a/src/core/ObservablesCollector.h
+++ b/src/core/ObservablesCollector.h
@@ -15,6 +15,13 @@
 #include "BulkObservable.h"
 #include "utils/Quantity.h"
 
+
+class IncompatibleObservablesHeaderException : public ValidationException {
+public:
+    using ValidationException::ValidationException;
+};
+
+
 /**
  * @brief The class responsible for collection and storing of all Observable -s and BulkObservable -s.
  * @details The class is responsible for three possible observable scopes: snapshots, inline printing on the standard
@@ -37,14 +44,15 @@ private:
     std::vector<std::size_t> snapshotCycleNumbers;
     std::vector<std::vector<std::string>> snapshotValues;
     std::vector<std::vector<double>> averagingValues;
-    std::unique_ptr<std::ostream> onTheFlyOut;
+    std::unique_ptr<std::iostream> onTheFlyOut;
 
     mutable double computationMicroseconds{};
 
     void printInlineObservable(unsigned long observableIdx, const Packing &packing, const ShapeTraits &shapeTraits,
                                std::ostringstream &out) const;
-    void doPrintSnapshotHeader(std::ostream &out) const;
+    void doPrintSnapshotHeader(std::ostream &out, bool printNewline = true) const;
     void doPrintSnapshotValues(std::ostream &out, std::size_t snapshotIdx) const;
+    void verifyOnTheFlyOutputHeader();
 
 public:
     /**
@@ -116,9 +124,10 @@ public:
     /**
      * @brief Starts saving observable snapshots "on the fly" to the output stream @a out.
      * @details If something was attached previously, its destructor is called. If @a nullptr is passed, it is analogous
-     * to calling detachOnTheFlyOutput.
+     * to calling detachOnTheFlyOutput. If the output is not empty, the method verifies if has a correct header to
+     * ensure consistency of outputted observables.
      */
-    void attachOnTheFlyOutput(std::unique_ptr<std::ostream> out);
+    void attachOnTheFlyOutput(std::unique_ptr<std::iostream> out);
 
     /**
      * @brief Detaches and returns "on the fly" output stream (or @a nullptr if nothing is attached).

--- a/src/core/ObservablesCollector.h
+++ b/src/core/ObservablesCollector.h
@@ -16,12 +16,6 @@
 #include "utils/Quantity.h"
 
 
-class IncompatibleObservablesHeaderException : public ValidationException {
-public:
-    using ValidationException::ValidationException;
-};
-
-
 /**
  * @brief The class responsible for collection and storing of all Observable -s and BulkObservable -s.
  * @details The class is responsible for three possible observable scopes: snapshots, inline printing on the standard

--- a/src/core/SimulationRecorder.h
+++ b/src/core/SimulationRecorder.h
@@ -22,6 +22,11 @@ public:
     virtual void recordSnapshot(const Packing &packing, std::size_t cycle) = 0;
 
     /**
+     * @brief Returns last recorder cycle number.
+     */
+     [[nodiscard]] virtual std::size_t getLastCycleNumber() const = 0;
+
+    /**
      * @brief Closes the underlying sink on demand and prevents any further operations.
      */
     virtual void close() = 0;

--- a/src/core/io/RamtrjRecorder.h
+++ b/src/core/io/RamtrjRecorder.h
@@ -46,6 +46,7 @@ public:
      */
     void recordSnapshot(const Packing &packing, std::size_t cycle) override;
 
+    [[nodiscard]] std::size_t getLastCycleNumber() const override { return this->numSnapshots * this->cycleStep; }
     void close() override { this->close0(); }
 };
 

--- a/src/core/io/XYZRecorder.cpp
+++ b/src/core/io/XYZRecorder.cpp
@@ -4,6 +4,8 @@
 
 #include "XYZRecorder.h"
 #include "XYZWriter.h"
+#include "utils/GetlineBackwards.h"
+#include "utils/Utils.h"
 
 
 void XYZRecorder::recordSnapshot(const Packing &packing, std::size_t cycle) {
@@ -11,4 +13,44 @@ void XYZRecorder::recordSnapshot(const Packing &packing, std::size_t cycle) {
 
     XYZWriter writer;
     writer.write(*this->out, packing, {{"cycles", std::to_string(cycle)}});
+
+    this->lastCycleNumber = cycle;
+}
+
+XYZRecorder::XYZRecorder(std::unique_ptr<std::iostream> out, bool append)
+        : out{std::move(out)}
+{
+    Expects(this->out != nullptr);
+
+    this->out->seekp(0, std::ios::end);
+    if (append) {
+        if (this->out->tellp() != 0)
+            this->findLastCycleNumber();
+    } else {
+        ValidateMsg(this->out->tellp() == 0, "XYZRecorder: append = false however stream is not empty");
+    }
+}
+
+void XYZRecorder::findLastCycleNumber() {
+    this->out->seekg(0, std::ios::end);
+
+    std::string line;
+    while (GetlineBackwards::getline(*this->out, line)) {
+        if (!startsWith(line, "Lattice"))
+            continue;
+
+        std::size_t pos = line.find("cycles=");
+        if (pos == std::string::npos)
+            break;
+
+        std::istringstream cyclesStream(line);
+        cyclesStream.seekg(static_cast<std::streamoff>(pos) + 7);
+        cyclesStream >> this->lastCycleNumber;
+        if (!cyclesStream)
+            break;
+
+        return;
+    }
+
+    throw ValidationException("XYZRecorder: Cannot read last snapshot number - malformed XYZ stream");
 }

--- a/src/core/io/XYZRecorder.h
+++ b/src/core/io/XYZRecorder.h
@@ -21,10 +21,13 @@
  */
 class XYZRecorder : public SimulationRecorder {
 private:
-    std::unique_ptr<std::ostream> out;
+    std::unique_ptr<std::iostream> out;
+    std::size_t lastCycleNumber{};
+
+    void findLastCycleNumber();
 
 public:
-    explicit XYZRecorder(std::unique_ptr<std::ostream> out) : out{std::move(out)} { }
+    explicit XYZRecorder(std::unique_ptr<std::iostream> out, bool append);
     ~XYZRecorder() override = default;
 
     /**
@@ -33,6 +36,7 @@ public:
      */
     void recordSnapshot(const Packing &packing, std::size_t cycle) override;
 
+    [[nodiscard]] std::size_t getLastCycleNumber() const override { return this->lastCycleNumber; }
     void close() override { this->out = nullptr; }
 };
 

--- a/src/frontend/SimulationRecorderFactory.cpp
+++ b/src/frontend/SimulationRecorderFactory.cpp
@@ -21,8 +21,7 @@ std::unique_ptr<SimulationRecorder> RamtrjRecorderFactory::create(std::size_t nu
         );
     } else {
         inout = std::make_unique<std::fstream>(
-                this->filename,
-            std::ios_base::in | std::ios_base::out | std::ios_base::binary | std::ios_base::trunc
+            this->filename, std::ios_base::in | std::ios_base::out | std::ios_base::binary | std::ios_base::trunc
         );
     }
 
@@ -37,12 +36,17 @@ std::unique_ptr<SimulationRecorder> XYZRecorderFactory::create([[maybe_unused]] 
 {
     std::unique_ptr<std::fstream> inout;
 
-    if (isContinuation)
-        inout = std::make_unique<std::fstream>(this->filename, std::ios_base::app);
-    else
-        inout = std::make_unique<std::fstream>(this->filename, std::ios_base::out);
+    if (isContinuation) {
+        inout = std::make_unique<std::fstream>(
+            this->filename, std::ios_base::in | std::ios_base::out | std::ios_base::ate
+        );
+    } else {
+        inout = std::make_unique<std::fstream>(
+            this->filename,std::ios_base::in | std::ios_base::out | std::ios_base::trunc
+        );
+    }
 
     ValidateOpenedDesc(*inout, this->filename, "to store XYZ trajectory");
     logger.info() << "XYZ trajectory is stored on the fly to '" << this->filename << "'" << std::endl;
-    return std::make_unique<XYZRecorder>(std::move(inout));
+    return std::make_unique<XYZRecorder>(std::move(inout), isContinuation);
 }

--- a/src/frontend/modes/CasinoMode.cpp
+++ b/src/frontend/modes/CasinoMode.cpp
@@ -515,11 +515,11 @@ void CasinoMode::overwriteMoveStepSizes(Simulation::Environment &env,
 void CasinoMode::attachSnapshotOut(ObservablesCollector &collector, const std::string &filename,
                                    bool isContinuation) const
 {
-    std::unique_ptr<std::ofstream> out;
+    std::unique_ptr<std::fstream> out;
     if (isContinuation)
-        out = std::make_unique<std::ofstream>(filename, std::ios_base::app);
+        out = std::make_unique<std::fstream>(filename, std::ios_base::in | std::ios_base::out | std::ios_base::app);
     else
-        out = std::make_unique<std::ofstream>(filename);
+        out = std::make_unique<std::fstream>(filename, std::ios_base::in | std::ios_base::out | std::ios_base::trunc);
 
     ValidateOpenedDesc(*out, filename, "to store observables");
     this->logger.info() << "Observable snapshots are stored on the fly to '" << filename << "'" << std::endl;

--- a/src/frontend/modes/CasinoMode.cpp
+++ b/src/frontend/modes/CasinoMode.cpp
@@ -578,11 +578,17 @@ void CasinoMode::OnTheFlyOutput
     bool numbersConsistent = std::all_of(lastCycleNumbers.begin(), lastCycleNumbers.end(), isCycleNumberCorrect);
     if (numbersConsistent)
         return;
+    else
+        this->throwInconsistencyException(lastCycleNumbers);
+}
 
+void CasinoMode::OnTheFlyOutput
+    ::throwInconsistencyException(const std::vector<std::pair<std::string, std::size_t>> &lastCycleNumbers) const
+{
     std::vector<std::pair<std::string, std::string>> errorListEntries{
-        {"Total cycles", std::to_string(this->absoluteCyclesNumber)},
-        {"Snapshot every", std::to_string(this->snapshotEvery)},
-        {"Last snapshot cycles", std::to_string(this->roundedCyclesNumber)}
+            {"Total cycles", std::to_string(this->absoluteCyclesNumber)},
+            {"Snapshot every", std::to_string(this->snapshotEvery)},
+            {"Last snapshot cycles", std::to_string(this->roundedCyclesNumber)}
     };
 
     for (const auto&[filename, cycles] : lastCycleNumbers)

--- a/src/frontend/modes/CasinoMode.h
+++ b/src/frontend/modes/CasinoMode.h
@@ -14,6 +14,27 @@
 
 class CasinoMode : public ModeBase {
 private:
+    // Helper class for managing and validating on-the-fly output channels
+    class OnTheFlyOutput {
+    private:
+        std::size_t absoluteCyclesNumber{};
+        std::size_t roundedCyclesNumber{};
+        std::size_t snapshotEvery{};
+        bool isContinuation{};
+        Logger &logger;
+
+        void attachSnapshotOut(const std::string &filename) const;
+        void verifyLastCycleNumbers(const std::vector<std::pair<std::string, std::size_t>> &lastCycleNumbers) const;
+
+    public:
+        std::shared_ptr<ObservablesCollector> collector;
+        std::vector<std::unique_ptr<SimulationRecorder>> recorders;
+
+        OnTheFlyOutput(const Run &run, std::size_t numParticles, std::size_t absoluteCyclesNumber, bool isContinuation,
+                       Logger &logger);
+    };
+
+
     [[nodiscard]] Simulation::Environment recreateEnvironment(const RampackParameters &params, const PackingLoader &loader) const;
     void verifyDynamicParameter(const DynamicParameter &dynamicParameter, const std::string &parameterName,
                                 const IntegrationRun &run, std::size_t cycleOffset) const;
@@ -24,7 +45,6 @@ private:
                                   bool isContinuation);
     void overwriteMoveStepSizes(Simulation::Environment &env,
                                 const std::map<std::string, std::string> &packingAuxInfo) const;
-    void attachSnapshotOut(ObservablesCollector &collector, const std::string& filename, bool isContinuation) const;
     void printPerformanceInfo(const Simulation &simulation);
     void printAverageValues(const ObservablesCollector &collector);
     void printMoveStatistics(const Simulation &simulation) const;

--- a/src/frontend/modes/CasinoMode.h
+++ b/src/frontend/modes/CasinoMode.h
@@ -26,6 +26,9 @@ private:
         void attachSnapshotOut(const std::string &filename) const;
         void verifyLastCycleNumbers(const std::vector<std::pair<std::string, std::size_t>> &lastCycleNumbers) const;
 
+        void
+        throwInconsistencyException(const std::vector<std::pair<std::string, std::size_t>> &lastCycleNumbers) const;
+
     public:
         std::shared_ptr<ObservablesCollector> collector;
         std::vector<std::unique_ptr<SimulationRecorder>> recorders;

--- a/src/utils/GetlineBackwards.cpp
+++ b/src/utils/GetlineBackwards.cpp
@@ -1,0 +1,41 @@
+//
+// Created by Piotr Kubala on 13/06/2023.
+//
+
+#include "GetlineBackwards.h"
+
+
+std::istream &GetlineBackwards::getline(std::istream &in, std::string &line, char delim) {
+    line.clear();
+
+    if (in.fail())
+        return in;
+
+    if (in.tellg() == 0) {
+        in.setstate(std::ios::failbit);
+        return in;
+    }
+
+    if (in.eof())
+        in.clear();
+
+    bool keepSearching = true;
+    std::streampos beforeLine;
+    while (keepSearching) {
+        in.seekg(-1, std::ios::cur);
+        if (in.tellg() == 0 || in.peek() == delim) {
+            keepSearching = false;
+            beforeLine = in.tellg();
+        }
+    }
+
+    if (in.peek() == delim)
+        in.get();
+
+    // Getline does not like getting EOF at the start and sets failbit - prevent it
+    if (in.peek() != EOF)
+        std::getline(in, line, delim);
+
+    in.seekg(beforeLine);
+    return in;
+}

--- a/src/utils/GetlineBackwards.h
+++ b/src/utils/GetlineBackwards.h
@@ -1,0 +1,37 @@
+//
+// Created by Piotr Kubala on 13/06/2023.
+//
+
+#ifndef RAMPACK_GETLINEBACKWARDS_H
+#define RAMPACK_GETLINEBACKWARDS_H
+
+#include <istream>
+
+
+/**
+ * @brief Class for extracting lines from the stream in the reverse order.
+ */
+class GetlineBackwards {
+public:
+    /**
+     * @brief Reads the line which @b precedes the current stream position.
+     * @details <p>It reads all characters between [@a start, @a end) (@a start inclusive, @a end exclusive), where
+     * @a end = `in.tellg()` and @a start is one character after first @a delim occurrence before @a end or the
+     * beginning of the stream if reached before finding @a delim. The line is stored to @a line argument.
+     *
+     * <p> After the operation, `in.tellg()` points at the @a delim preceding the extracted line of the beginning or the
+     * stream. Thus, subsequent method invocations on a stream with its read pointer at the end
+     * `in.seekg(0, std::ios::end)` extract subsequent lines in the stream from the end.
+     *
+     * <p> It clears `std::ios::eofbit` flag from the stream state. If `in.tellg() == 0`, no preceding line can be
+     * extracted and `std::ios::failbit` is set.
+     * @param in the stream to extract the line from
+     * @param line `std::string` to store the line
+     * @param delim line delimiter
+     * @return @a in
+     */
+    static std::istream &getline(std::istream &in, std::string &line, char delim = '\n');
+};
+
+
+#endif //RAMPACK_GETLINEBACKWARDS_H

--- a/src/utils/Version.h
+++ b/src/utils/Version.h
@@ -97,7 +97,7 @@ public:
 };
 
 
-constexpr Version CURRENT_VERSION{0, 14, 0};
+constexpr Version CURRENT_VERSION{0, 15, 0};
 
 // Auxiliary versions user in the code
 

--- a/test/unit_tests/core/ObservablesCollectorTest.cpp
+++ b/test/unit_tests/core/ObservablesCollectorTest.cpp
@@ -95,13 +95,13 @@ TEST_CASE("ObservablesCollector") {
         }
 
         SECTION("on the fly snapshots") {
-            std::stringbuf buf(std::ios::out);
+            std::stringbuf buf(std::ios::in | std::ios::out);
 
-            auto out1 = std::make_unique<std::ostream>(&buf);
+            auto out1 = std::make_unique<std::iostream>(&buf);
             collector.attachOnTheFlyOutput(std::move(out1));
             collector.addSnapshot(packing, 100, mockShapeTraits);
             packing.tryScaling(2, mockShapeTraits.getInteraction());
-            auto out2 = std::make_unique<std::ostream>(&buf);
+            auto out2 = std::make_unique<std::iostream>(&buf);
             collector.attachOnTheFlyOutput(std::move(out2));
             collector.addSnapshot(packing, 200, mockShapeTraits);
 

--- a/test/unit_tests/core/io/XYZRecorderTest.cpp
+++ b/test/unit_tests/core/io/XYZRecorderTest.cpp
@@ -22,10 +22,10 @@ TEST_CASE("XYZRecorder") {
     std::stringbuf outBuf;
 
     {
-        auto out = std::make_unique<std::ostream>(&outBuf);
+        auto out = std::make_unique<std::iostream>(&outBuf);
         out->precision(1);
         *out << std::fixed;
-        XYZRecorder recorder(std::move(out));
+        XYZRecorder recorder(std::move(out), false);
         recorder.recordSnapshot(packing, 1000);
         packing.tryScaling(2, traits.getInteraction());
         recorder.recordSnapshot(packing, 2000);
@@ -44,4 +44,10 @@ A 9.0 1.0 1.0 0.0 0.0 0.0 1.0
 A 5.0 5.0 8.0 0.0 0.0 0.0 1.0
 )";
     CHECK(outBuf.str() == expectedOut);
+
+    SECTION("last cycle number when appending") {
+        auto out = std::make_unique<std::iostream>(&outBuf);
+        XYZRecorder recorder(std::move(out), true);
+        CHECK(recorder.getLastCycleNumber() == 2000);
+    }
 }

--- a/test/unit_tests/utils/GetlineBackwardsTest.cpp
+++ b/test/unit_tests/utils/GetlineBackwardsTest.cpp
@@ -1,0 +1,43 @@
+//
+// Created by Piotr Kubala on 13/06/2023.
+//
+
+#include <catch2/catch.hpp>
+#include <sstream>
+
+#include "utils/GetlineBackwards.h"
+
+
+TEST_CASE("GetlineBackwards: general") {
+    std::istringstream in("first line\n\nthird line\n");
+    in.seekg(0, std::ios::end);
+
+    std::string line;
+
+    REQUIRE(GetlineBackwards::getline(in, line));
+    CHECK(line == "");
+    CHECK(in.tellg() == 22);   // 3rd '\n'
+
+    REQUIRE(GetlineBackwards::getline(in, line));
+    CHECK(line == "third line");
+    CHECK(in.tellg() == 11);   // 2nd '\n'
+
+    REQUIRE(GetlineBackwards::getline(in, line));
+    CHECK(line == "");
+    CHECK(in.tellg() == 10);   // 1st '\n'
+
+    REQUIRE(GetlineBackwards::getline(in, line));
+    CHECK(line == "first line");
+    CHECK(in.tellg() == 0);
+
+    REQUIRE(!GetlineBackwards::getline(in, line));
+}
+
+TEST_CASE("GetlineBackwards: delimiter") {
+    std::istringstream in("first\nline#second\nline");
+    in.seekg(0, std::ios::end);
+
+    std::string line;
+    REQUIRE(GetlineBackwards::getline(in, line, '#'));
+    CHECK(line == "second\nline");
+}

--- a/test/validation_tests/SimulationIOTest.cpp
+++ b/test/validation_tests/SimulationIOTest.cpp
@@ -111,6 +111,7 @@ TEST_CASE("Simulation IO: storing and restoring")
         std::vector<std::unique_ptr<SimulationRecorder>> recorders2;
         recorders2.push_back(std::make_unique<RamtrjRecorder>(std::move(inout_stream2), simulation.getPacking().size(),
                                                               100, true));
+        CHECK(recorders2.front()->getLastCycleNumber() == 1000);
         auto collector2 = std::make_unique<ObservablesCollector>();
         simulation.integrate(1, 1, 500, 500, 100, 100, traits, std::move(collector2), std::move(recorders2), logger,
                              1000);
@@ -138,6 +139,7 @@ TEST_CASE("Simulation IO: storing and restoring")
         std::vector<std::unique_ptr<SimulationRecorder>> recorders2;
         recorders2.push_back(std::make_unique<RamtrjRecorder>(std::move(inout_stream2), simulation.getPacking().size(),
                                                               100, true));
+        CHECK(recorders2.front()->getLastCycleNumber() == 0);
         auto collector2 = std::make_unique<ObservablesCollector>();
         simulation.integrate(1, 1, 500, 500, 100, 100, traits, std::move(collector2), std::move(recorders2), logger);
 


### PR DESCRIPTION
Coherence of on-the-fly output formats it now checked. It includes:
- header in observables output
- last stored snapshot in observables output and trajectory recordings